### PR TITLE
Improved the addrole & roles commands - Zen

### DIFF
--- a/commands/addrole.js
+++ b/commands/addrole.js
@@ -1,23 +1,40 @@
 exports.run = (client, message, args) => {
     try {
-    let roleSearch = args.join(" ")
-    let roleToAdd = message.guild.roles.find(x => x.name === roleSearch)
+    let roleSearch = args.join(" ").toLowerCase();
+    let roleToAdd = message.guild.roles.find(x => x.name.toLowerCase() === roleSearch)
     
-    if(!roleSearch) return message.reply('please provide a role for me to add.')
-    if(message.member.roles.has(roleToAdd.id)) return message.reply('you already have that role!')
-    if(!roleToAdd) return message.reply(`That role, **${roleSearch}**, does not exist.`)
+   
 
-    message.member.addRole(`${roleToAdd.id}`).then(() => message.react(`✅`)).catch(console.error)
+    if(!roleSearch) 
+        return message.reply('Gimmie a role ya big silly')
 
-    setTimeout( () => {
-        message.delete();
-    }, 5000 )
+    if(roleToAdd == undefined) 
+        return message.reply(`Unfortunately that role, **${roleSearch}**, does not exist`)
+
+    if(message.member.roles.has(roleToAdd.id)) 
+        return message.reply('You already have that role!');
+    
+
+    message.member.addRole(`${roleToAdd.id}`).then(() => message.react(`✅`))
+    .catch(error => {
+        console.error;
+        message.react('❎');
+        if(error == "DiscordAPIError: Missing Permissions")
+            return message.reply(`You lack the power to gain a role as noble as ${roleToAdd}`);
+        else
+            return message.reply(`Unexpected error | ${error}`)
+    })
+
+  
     } catch (err) {
-        console.log('There was an error: ' + err)
+        console.log('There was an error adding a role: ' + err)
     }
 }
 exports.help = {
     name: "addrole",
-    description: "Allows bot to give you the provided role",
-    usage: "`yabe addrole <role\'s name>(case sensitive)`",
+    description: "Allows yabe to give you the provided role",
+    usage: "`yabe addrole <role\'s name>`",
 }
+
+
+// Improved by best waifu Zen

--- a/commands/roles.js
+++ b/commands/roles.js
@@ -1,24 +1,38 @@
 const Discord = require('discord.js')
 
 exports.run = (client, message, args) => {
-    let roles = message.guild.roles.filter(y => y.name !== '@everyone').array().sort()
+    // Role names inside the blacklist won't be included in the final list
+    // Find all roles below the Coding Yabe Sei role, filter out the blacklist roles, and filter out any roles with the Administrator permission 
+    // (to avoid any no perms message if a user were to try and add the role) - and then sort the filter and convert it into an array
+    try{
+    var blackList = ["@everyone"]
 
-    let rolesDel = roles.join(' ')
-    let rolesStr = rolesDel.toString()
+    let yabeRole = message.guild.roles.find(yaberole => yaberole.name == "Coding Yabe Sei")
+    let roles = message.guild.roles.filter(allRoles => allRoles.calculatedPosition < yabeRole.calculatedPosition && !blackList.includes(allRoles.name) 
+    && !allRoles.hasPermission("ADMINISTRATOR"))
+    .sort().array();
+
+
 
     let embed = new Discord.RichEmbed()
     .setColor(client.config.embedColor)
-    .setTitle(`These are the ${roles.length} roles for ` + message.guild.name + '\n')
-    .setDescription(rolesStr)
-    .addField('Add roles with Yabe with `yabe addrole <role name>`', 'Note: roles higher than Yabe\'s may not be added, so keep all admin roles above Yabe\'s role and all addable roles below Yabe\'s role')
+    .setTitle(`These are the ${roles.length} roles avaliable to you for ` + message.guild.name + '\n')
+    .setDescription(roles.join(' '))
+    .addField('Add roles using Yabe with `yabe addrole <role name>`', 'Note: Only roles below the \`Coding Yabe Sei\` role are displayed')
     .setTimestamp()
 
     message.channel.send(embed)
-    console.log(roles.length)
+    //console.log(roles.length)
+} catch (err) {
+    console.log('There was an error displaying roles: ' + err)
+    }
 }
+
 
 exports.help = {
     name: "roles",
-    description: "The `roles` command displays all roles for the server.",
+    description: "The `roles` command displays all roles below the \`Coding Yabe Sei\` role.",
     usage: "`yabe roles`"
 }
+
+//Improved by yabe's favorite father-in-law Zen


### PR DESCRIPTION
Improved the addrole & roles commands | The roles command will now only display roles below the Coding Yabe Sei role, nor will it display Administrator roles, I've also added a blacklist of roles to not display | For the addrole command I've made selecting a role case-insensitive - It will also now provide feedback on failure, there was previously code for this but it simply did not work and left the user with no output on failure(thanks cenny) - I've removed deleting the command message as that makes me big annoyed

This is my first contribution to my daughter-in-law Yabe <3