### PR TITLE
Addrole command improved

### DIFF
--- a/commands/utility/addrole.js
+++ b/commands/utility/addrole.js
@@ -7,7 +7,9 @@ exports.run = (client, message, args) => {
         if (!roleSearch)
             return message.reply('Gimmie a role ya big silly');
 
-        if (roleToAdd == undefined)
+        if (roleToAdd == undefined && roleSearch.match(/<|>/gm))
+            roleToAdd = message.guild.roles.find(x => x.name.toLowerCase() === roleSearch.replace(/<|>/gm, ""));
+        else if (roleToAdd == undefined)
             return message.reply(`Unfortunately that role, **${roleSearch}**, does not exist`);
 
         if (message.member.roles.has(roleToAdd.id))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38158426/68574792-f879d580-046a-11ea-9ccc-a9ed0d839740.png)  
  
> Since many people don't get that they can't include the `<>` when adding a role, I added a regex search and replace.  
  
### Examples:
- Role `<test>` exists, user enters command `yabe addrole <test>`: user successfully gets the role `<test>`
- Role `test` exists, user enters command `yabe addrole <test>`: user successfully gets the role `test`
- Role `<test>` exists, user enters command `yabe addrole test`: user does not get the role `<test>`