### PR TITLE
Whois: Made names clickable + always displaying up to 50 users, even if there's more than that

### DIFF
--- a/commands/info/whois.js
+++ b/commands/info/whois.js
@@ -2,40 +2,44 @@ const Discord = require("discord.js");
 
 exports.run = (client, message, args) => {
 	try {
+		let maxUsersToDisplay = 2;
+
 		let roles = message.guild.roles;
 		let roleKeys = roles.keyArray();
-
-		var sendEmbed = (name, role) => {
+	
+		let sendEmbed = (name, role) => {
 			let memberNames = [];
-			let roleMembers = [];
-
+	
 			let roleKeys = role.keyArray()
-			for (key of roleKeys) { memberNames.push(role.get(key)) };
-
+			roleKeys.forEach(key => memberNames.push(role.get(key)));
+	
 			let emb = new Discord.RichEmbed();
-
-			//emb.description = "Who is..." + name;
+	
 			emb.setColor(client.config.embedColor);
+	
+			let memberUsers = "";
+			let moreThanMax = false;
+			let memberCount = memberNames.length;
+			let tooManyText = "";
 
-			let memberUsers = ""
-			if (memberNames.length > 50) {
-				let embed = new Discord.RichEmbed()
-					.setDescription(`Too many users to display: ${memberNames.length} users.`)
-					.setColor(client.config.embedColor)
+			if (memberNames.length > maxUsersToDisplay)
+			{
+				memberNames.splice(maxUsersToDisplay);
+				moreThanMax = true;
+				tooManyText = " (too many to display)";
+			}
+			
+			memberNames.forEach(member => memberUsers += member.user + "\n");
 
-				message.channel.send(embed)
-				return
-			} //return message.channel.send(`Too many users to display: ${memberNames.length} users`)
-			for (member of memberNames) {
-				memberUsers += member.user.username + "\n"
-			};
-
-			emb.addField(`Who is ${name}`, memberUsers);
-			emb.setFooter(`${memberNames.length} users have this role.`)
+			if(moreThanMax)
+				memberUsers += "...";
+	
+			emb.addField(`Who is ${name}:`, memberUsers);
+			emb.setFooter(`${memberCount} users have this role${tooManyText}.`)
 			message.channel.send(emb);
 		};
-
-		for (key of roleKeys) {
+	
+		roleKeys.forEach(key => {
 			let role = roles.get(key);
 			let name = role.name;
 			let argS = args.join(' ');
@@ -43,7 +47,7 @@ exports.run = (client, message, args) => {
 				sendEmbed(name, role.members);
 				return;
 			}
-		}
+		});
 	} catch (err) {
 		console.log(err)
 	}

--- a/commands/info/whois.js
+++ b/commands/info/whois.js
@@ -6,17 +6,17 @@ exports.run = (client, message, args) => {
 
 		let roles = message.guild.roles;
 		let roleKeys = roles.keyArray();
-	
+
 		let sendEmbed = (name, role) => {
 			let memberNames = [];
-	
+
 			let roleKeys = role.keyArray()
 			roleKeys.forEach(key => memberNames.push(role.get(key)));
-	
+
 			let emb = new Discord.RichEmbed();
-	
+
 			emb.setColor(client.config.embedColor);
-	
+
 			let memberUsers = "";
 			let moreThanMax = false;
 			let memberCount = memberNames.length;
@@ -33,12 +33,12 @@ exports.run = (client, message, args) => {
 
 			if(moreThanMax)
 				memberUsers += "...";
-	
+
 			emb.addField(`Who is ${name}:`, memberUsers);
 			emb.setFooter(`${memberCount} users have this role${tooManyText}.`)
 			message.channel.send(emb);
 		};
-	
+
 		roleKeys.forEach(key => {
 			let role = roles.get(key);
 			let name = role.name;

--- a/commands/info/whois.js
+++ b/commands/info/whois.js
@@ -2,7 +2,7 @@ const Discord = require("discord.js");
 
 exports.run = (client, message, args) => {
 	try {
-		let maxUsersToDisplay = 2;
+		let maxUsersToDisplay = 50;
 
 		let roles = message.guild.roles;
 		let roleKeys = roles.keyArray();


### PR DESCRIPTION
The usernames are now clickable, meaning right-clicking / tapping them makes mentioning and managing the user very easy (don't worry, it will not ping the users, I have tested that).  
Also now there will always be displayed up to 50 users, but if the amount of users exceeds this number, a `...` will be added to the last line and the footer will be updated with the actual number of members with the role and the text `(too many to display)`.  

Example with a limit of 2:  
![image](https://user-images.githubusercontent.com/38158426/72156297-80ba1f80-33b5-11ea-91ce-83f073a63db9.png)  

Same example but with limit of 50:  
![image](https://user-images.githubusercontent.com/38158426/72156351-a0514800-33b5-11ea-90a2-bd842b95f3d0.png)