### PR TITLE
Yabe doesn't ping roles anymore

### DIFF
--- a/commands/utility/addrole.js
+++ b/commands/utility/addrole.js
@@ -20,7 +20,7 @@ exports.run = (client, message, args) => {
                 console.error;
                 message.react('❎');
                 if (error == "DiscordAPIError: Missing Permissions")
-                    return message.reply(`You lack the power to gain a role as noble as ${roleToAdd}`);
+                    return message.reply(`You lack the power to gain a role as noble as \`${roleToAdd.name || roleToAdd}\``);
                 else
                     return message.reply(`Unexpected error | ${error}`);
             })


### PR DESCRIPTION
If the role for some reason has no `name` property, it defaults back to the original.